### PR TITLE
Bugfix - turn useFullStack into a boolean on common

### DIFF
--- a/src/initialization.js
+++ b/src/initialization.js
@@ -6,7 +6,7 @@ var initialization = {
     name: 'Optimizely',
     moduleId: 54,
     initForwarder: function(settings, testMode, userAttributes, userIdentities, processEvent, eventQueue, isInitialized, common, appVersion, appName, customFlags, clientId) {
-        common.useFullStack = settings.useFullStack;
+        common.useFullStack = settings.useFullStack === 'True';
 
         if (!testMode) {
             if (!window.optimizely && !settings.useFullStack) {


### PR DESCRIPTION
Our server returns booleans as capitalized strings. ie. If something is checked to be true in the UI, the server returns `"True"` instead of `true` and `"False"` instead of `false`. 

This is an issue because it means that anytime we program conditionally off of `useFullStack`, it will always evaluate to true since `"False"` is truthy (it's a non-empty string).

This fix sets common.useFullStack to be a boolean. 