### PR TITLE
Bugfix - remove other instances of settings.useFullStack

### DIFF
--- a/src/initialization.js
+++ b/src/initialization.js
@@ -9,7 +9,7 @@ var initialization = {
         common.useFullStack = settings.useFullStack === 'True';
 
         if (!testMode) {
-            if (!window.optimizely && !settings.useFullStack) {
+            if (!window.optimizely && !common.useFullStack) {
                 var optimizelyScript = document.createElement('script');
                 optimizelyScript.type = 'text/javascript';
                 optimizelyScript.async = true;
@@ -32,7 +32,7 @@ var initialization = {
                 loadWebXEventsAndPages();
             }
 
-            if (!window.optimizelyClientInstance && settings.useFullStack) {
+            if (!window.optimizelyClientInstance && common.useFullStack) {
                 common.userIdField = settings.userIdField;
                 common.userAttributes = userAttributes;
                 var errorHandler = function() {};
@@ -62,10 +62,10 @@ var initialization = {
             }            
         } else {
             isInitialized = true;
-            if (!settings.useFullStack) {
+            if (!common.useFullStack) {
                 loadWebXEventsAndPages();
             }
-            if (settings.useFullStack) {
+            if (common.useFullStack) {
                 common.userIdField = settings.userIdField;
                 common.userAttributes = userAttributes;
                 loadFullStackEvents();


### PR DESCRIPTION
The previous PR set `common.useFullStack` which is used in other modules, but the initialization.js module that it is set in still has a few instances where `settings.useFullStack` is used.