### PR TITLE
fix: Correct casing for customerid

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -18,8 +18,10 @@ var helpers = {
         var userIdentities = identities['userIdentities'];
         var userId;
         switch(userIdField) {
+            // The server returns `customerId` as part of the `userIdField` setting
+            // but the API for identity requies it to be cased as `customerid`
             case 'customerId':
-                userId = userIdentities['customerId'];
+                userId = userIdentities['customerid'];
                 break;
             case 'email':
                 userId = userIdentities['email'];


### PR DESCRIPTION
There is a casing issue. While `customerId` is expected as a value from the server setting for `userIdField`, the casing is `customerid` when using the Identity API.  This was brought up in issue https://github.com/mparticle-integrations/mparticle-javascript-integration-optimizely/issues/32