### PR TITLE
fix: update datafile loading callback

### DIFF
--- a/src/initialization.js
+++ b/src/initialization.js
@@ -53,8 +53,17 @@ var initialization = {
                     });  
                 }
 
-                helpers.loadScript('https://unpkg.com/@optimizely/optimizely-sdk/dist/optimizely.browser.umd.min.js', 
-                helpers.loadScript('https://cdn.optimizely.com/datafiles/' + settings.projectId + '.json/tag.js', instantiateFSClient));
+                helpers.loadScript(
+                    'https://unpkg.com/@optimizely/optimizely-sdk@3.5.0/dist/optimizely.browser.umd.min.js',
+                    function() {
+                        helpers.loadScript(
+                            'https://cdn.optimizely.com/datafiles/' +
+                                settings.projectId +
+                                '.json/tag.js',
+                            instantiateFSClient
+                        );
+                    }
+                );
 
             } else {
                 isInitialized = true;

--- a/src/initialization.js
+++ b/src/initialization.js
@@ -2,6 +2,10 @@ var optimizelyWebXEvents = require('./optimizely-x-defined-events');
 var optimizelyFullStackEvents = require('./optimizely-fs-defined-events');
 var helpers = require('./helpers');
 
+var optimizelyFsSdkUrl = 'https://unpkg.com/@optimizely/optimizely-sdk@3.5.0/dist/optimizely.browser.umd.min.js',
+    dataFilePrefix = 'https://cdn.optimizely.com/datafiles/',
+    dataFileURLending = '.json/tag.js';
+
 var initialization = {
     name: 'Optimizely',
     moduleId: 54,
@@ -53,14 +57,13 @@ var initialization = {
                     });  
                 }
 
-                helpers.loadScript(
-                    'https://unpkg.com/@optimizely/optimizely-sdk@3.5.0/dist/optimizely.browser.umd.min.js',
+                helpers.loadScript(optimizelyFsSdkUrl,
                     function() {
                         helpers.loadScript(
-                            'https://cdn.optimizely.com/datafiles/' +
-                                settings.projectId +
-                                '.json/tag.js',
-                            instantiateFSClient
+                          dataFilePrefix +
+                            settings.projectId +
+                            dataFileURLending,
+                          instantiateFSClient
                         );
                     }
                 );


### PR DESCRIPTION
# Summary

The Optimizely web kit has a helper called [loadScript](https://github.com/mparticle-integrations/mparticle-javascript-integration-optimizely/blob/master/src/helpers.js#L9-L14) which takes a URL and a callback.  The callback is supposed to fire after the script loads.  

[Per Optimizely's docs](https://docs.developers.optimizely.com/full-stack/docs/javascript-browser) - we need to load 2 files (the optimizely SDK and the dataFile.js), and once dataFile.js loads, we instantiate optimizely using the Optimizely SDK:, ie
1. `https://unpkg.com/@optimizely/optimizely-sdk/dist/optimizely.browser.umd.min.js`, then
2. dataFile.js, then
3. call `window.optimizelysdk.createInstance(...)`

The reported bug is that the dataFile.js (2) was loading before (1), and (3) is triggered, which requires (1).

This PR fixes 2 bugs:
1. The previous url (1) is a generic url that redirects to the latest optimizely SDK. the `onload` will trigger after the redirect ocurs, as opposed to following the redirect and waiting for that to load. This is resolved by pointing to version 3.5.0 rather than just a generic dist/ file. There is no more redirect now!
2. The callback was previously being invoked, as opposed to being passed as a function to the `loadScript` method, where a callback is invoked after a script is loaded.  This is resolved by turning the method into a function.