### PR TITLE
add userIdField and userAttributes to common obj

### DIFF
--- a/src/initialization.js
+++ b/src/initialization.js
@@ -70,6 +70,8 @@ var initialization = {
 
             } else {
                 isInitialized = true;
+                common.userIdField = settings.userIdField;
+                common.userAttributes = userAttributes;
                 loadFullStackEvents();
             }            
         } else {


### PR DESCRIPTION
# Summary

When the `initForwarder` is called on the optimizely web kit, but there is already an instance of `optimizelyClientInstance` in the window, it will run the `loadFullStackEvents` without previously setting the `userIdField` in the common object. This will not cause any immediate issue, but later on, when the `logEvent` event handler is called it will try to retrieve this property and instead return the default id, the `deviceApplicationStamp`. This can be seen in the `helpers.getuserId` function.

This issue is only reproducible when:
- In the mParticle back office the id used for identifying events is changed from the default one (DeviceId, which is the same as the device application stamp) to another one such as the `Customer Id`.
- The client implementation sets a specific optimizely sdk version in the window object.
- The FullStack sdk is used

This issue causes:
- Events to not be tracked properly (experiment conversions don't happen) since it's using the default id instead of the specified one.

Feel free to modify, change or discard this PR if it hasn't been done in the proper way. Thanks for the help anyways.