### PR TITLE
fix: swap mpid origin

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -27,7 +27,7 @@ var helpers = {
                 userId = userIdentities['email'];
                 break;
             case 'mpid':
-                userId = userIdentities['mpid'];
+                userId = window.mParticle.Identity.getCurrentUser().getMPID();
                 break;
             case 'other':
                 userId = userIdentities['other'];


### PR DESCRIPTION
## Summary
When in the mParticle back office the connection with optimizely is using the `mparticle ID` rather than the default one, the tracking event is trying to get the mpid from the `userIdentities` object but I can’t see it present in said object when debugging, nor any reference of getting mpid from it in the documentation. I see that this id is already present in the window object by that point, so I have changed it to `mParticle.Identity.getCurrentUser().getMPID()` instead.

This issue is only reproducible when:
- In the mParticle back office the id used for identifying events is changed from the default one to the mparticle ID.
- The client implementation sets a specific optimizely sdk version in the window object.
- The FullStack sdk is used

This issue causes:
- Events to not be tracked properly (experiment conversions don't happen) since it's using the default id instead of the specified one.

I'm aware that there might be an alternative that I haven't considered, therefore feel free to modify, change or discard this PR if it doesn't fit your needs. Thanks for the help anyways.